### PR TITLE
added option to force the checksum when downloading db

### DIFF
--- a/conf/fingerbank.conf.defaults
+++ b/conf/fingerbank.conf.defaults
@@ -1,6 +1,7 @@
 [upstream]
 api_key =
 db_url = https://fingerbank.inverse.ca/api/v1/download
+db_force_checksum=enabled
 sqlite_db_retention = 2
 interrogate = enabled
 interrogate_url = https://fingerbank.inverse.ca/api/v1/combinations/interrogate

--- a/conf/fingerbank.conf.doc
+++ b/conf/fingerbank.conf.doc
@@ -10,6 +10,13 @@ description=<<EOT
 URL to fetch the upstream Fingerbank project database
 EOT
 
+[upstream.db_force_checksum]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Whether or not to discard a DB download if the checksum isn't provided with it
+EOT
+
 [upstream.sqlite_db_retention]
 type=numeric
 description=<<EOT

--- a/lib/fingerbank/DB.pm
+++ b/lib/fingerbank/DB.pm
@@ -22,7 +22,7 @@ use fingerbank::FilePath qw($INSTALL_PATH $LOCAL_DB_FILE $UPSTREAM_DB_FILE %SCHE
 use fingerbank::Log;
 use fingerbank::Schema::Local;
 use fingerbank::Schema::Upstream;
-use fingerbank::Util qw(is_success is_error is_disabled);
+use fingerbank::Util qw(is_success is_error is_disabled is_enabled);
 use fingerbank::DB;
 
 has 'schema'        => (is => 'rw');
@@ -116,8 +116,9 @@ sub update_upstream {
 
     my $download_url    = ( exists($params{'download_url'}) && $params{'download_url'} ne "" ) ? $params{'download_url'} : $Config->{'upstream'}{'db_url'};
     my $destination     = ( exists($params{'destination'}) && $params{'destination'} ne "" ) ? $params{'destination'} : $UPSTREAM_DB_FILE;
+    my $force_checksum  = ( exists($params{'force_checksum'}) ) ? $params{'force_checksum'} : is_enabled($Config->{'upstream'}{'db_force_checksum'});
 
-    ($status, $status_msg) = fingerbank::Util::update_file( ('download_url' => $download_url, 'destination' => $destination, %params) );
+    ($status, $status_msg) = fingerbank::Util::update_file( ('download_url' => $download_url, 'destination' => $destination, force_checksum => $force_checksum, %params) );
 
     fingerbank::Util::cleanup_backup_files($destination, $Config->{upstream}{sqlite_db_retention});
 

--- a/lib/fingerbank/Util.pm
+++ b/lib/fingerbank/Util.pm
@@ -279,6 +279,12 @@ sub fetch_file {
         $logger->info($status_msg);
         my $md5 = $res->header('X-Fingerbank-Md5');
         my $file_md5 = $ctx->hexdigest;
+        if($params{force_checksum} && !defined($md5)) {
+            undef $ua;
+            unlink($outfile) if -f $outfile;
+            $logger->error("Checksum is required and not provided in download. Ignoring downloaded file.");
+            return ($fingerbank::Status::INTERNAL_SERVER_ERROR, "Checksum is not provided with download");
+        }
         if(defined($md5) && $file_md5 ne $md5) {
             undef $ua;
             unlink($outfile) if -f $outfile;


### PR DESCRIPTION
# Description
Add an option (enabled by default) to force the MD5 check when downloading a DB. This prevents the DB to be installed if no checksum is provided

# Impacts
DB download

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Added option to force the checksum validation and ignore the DB download otherwise
