### PR TITLE
added option to force check of fingerbank upstream download

### DIFF
--- a/conf/fingerbank.conf.defaults
+++ b/conf/fingerbank.conf.defaults
@@ -1,6 +1,7 @@
 [upstream]
 api_key =
 db_url = https://fingerbank.inverse.ca/api/v1/download
+db_download_force_md5_check=enabled
 sqlite_db_retention = 2
 interrogate = enabled
 interrogate_url = https://fingerbank.inverse.ca/api/v1/combinations/interrogate

--- a/conf/fingerbank.conf.doc
+++ b/conf/fingerbank.conf.doc
@@ -10,6 +10,13 @@ description=<<EOT
 URL to fetch the upstream Fingerbank project database
 EOT
 
+[upstream.db_download_force_md5_check]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Whether or not to force the MD5 validation when downloading the Upstream DB. Should the Fingerbank API fail to provide the checksum along with the download, it will be discarded.
+EOT
+
 [upstream.sqlite_db_retention]
 type=numeric
 description=<<EOT

--- a/lib/fingerbank/DB.pm
+++ b/lib/fingerbank/DB.pm
@@ -22,7 +22,7 @@ use fingerbank::FilePath qw($INSTALL_PATH $LOCAL_DB_FILE $UPSTREAM_DB_FILE %SCHE
 use fingerbank::Log;
 use fingerbank::Schema::Local;
 use fingerbank::Schema::Upstream;
-use fingerbank::Util qw(is_success is_error is_disabled);
+use fingerbank::Util qw(is_success is_error is_disabled is_enabled);
 use fingerbank::DB;
 
 has 'schema'        => (is => 'rw');
@@ -117,7 +117,12 @@ sub update_upstream {
     my $download_url    = ( exists($params{'download_url'}) && $params{'download_url'} ne "" ) ? $params{'download_url'} : $Config->{'upstream'}{'db_url'};
     my $destination     = ( exists($params{'destination'}) && $params{'destination'} ne "" ) ? $params{'destination'} : $UPSTREAM_DB_FILE;
 
-    ($status, $status_msg) = fingerbank::Util::update_file( ('download_url' => $download_url, 'destination' => $destination, %params) );
+    ($status, $status_msg) = fingerbank::Util::update_file( (
+            'download_url' => $download_url, 
+            'destination' => $destination, 
+            'force_md5_check' => is_enabled($Config->{upstream}{db_download_force_md5_check}),
+            %params
+    ) );
 
     fingerbank::Util::cleanup_backup_files($destination, $Config->{upstream}{sqlite_db_retention});
 

--- a/lib/fingerbank/Util.pm
+++ b/lib/fingerbank/Util.pm
@@ -279,6 +279,12 @@ sub fetch_file {
         $logger->info($status_msg);
         my $md5 = $res->header('X-Fingerbank-Md5');
         my $file_md5 = $ctx->hexdigest;
+        if($params{force_md5_check} && !defined($md5)) {
+            undef $ua;
+            unlink($outfile) if -f $outfile;
+            $logger->error("Checksum validation was required but MD5 header was not present during download");
+            return ($fingerbank::Status::INTERNAL_SERVER_ERROR, "Checksum validation was required but not provided during download");
+        }
         if(defined($md5) && $file_md5 ne $md5) {
             undef $ua;
             unlink($outfile) if -f $outfile;


### PR DESCRIPTION
# Description
Adds the possibility to force the MD5 validation to occur when downloading the upstream DB

# Impacts
Upstream DB download

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Added option to force the checksum validation to occur and fail if its not possible when downloading the upstream DB
