### PR TITLE
add query for the new device-registration verification

### DIFF
--- a/lib/fingerbank/Base/Schema/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Base/Schema/CombinationMacVendorByDevice.pm
@@ -1,0 +1,33 @@
+package fingerbank::Base::Schema::CombinationMacVendorByDevice;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema';
+
+__PACKAGE__->table_class('DBIx::Class::ResultSource::View');
+
+__PACKAGE__->table('combinationmacvendorbydevice');
+
+__PACKAGE__->add_columns(
+    "device_id",
+);
+
+__PACKAGE__->set_primary_key('device_id');
+
+__PACKAGE__->result_source_instance->is_virtual(1);
+
+# $1 = mac_vendor
+#
+__PACKAGE__->view_with_named_params(q{
+    SELECT device_id FROM combination
+    WHERE mac_vendor_id = $1
+    GROUP BY device_id
+    HAVING COUNT(device_id) > 5
+    ORDER BY COUNT(device_id)
+    DESC LIMIT 1
+});
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/fingerbank/Base/Schema/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Base/Schema/CombinationMacVendorByDevice.pm
@@ -5,6 +5,16 @@ use namespace::autoclean;
 
 extends 'fingerbank::Base::Schema';
 
+=head1 NAME
+
+fingerbank::Base::Schema::CombinationMacVendorByDevice - DB query
+
+=head1 DESCRIPTION
+
+DB query
+
+=cut 
+
 __PACKAGE__->table_class('DBIx::Class::ResultSource::View');
 
 __PACKAGE__->table('combinationmacvendorbydevice');
@@ -27,6 +37,26 @@ __PACKAGE__->view_with_named_params(q{
     ORDER BY COUNT(device_id)
     DESC LIMIT 1
 });
+
+
+=head1 AUTHOR
+Inverse inc. <info@inverse.ca>
+=head1 COPYRIGHT
+Copyright (C) 2005-2017 Inverse inc.
+=head1 LICENSE
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+=cut
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/fingerbank/Schema/Local/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Schema/Local/CombinationMacVendorByDevice.pm
@@ -3,7 +3,36 @@ package fingerbank::Schema::Local::CombinationMacVendorByDevice;
 use Moose;
 use namespace::autoclean;
 
+=head1 NAME
+
+fingerbank::Schema::Local::CombinationMacVendorByDevice - DB query
+
+=head1 DESCRIPTION
+
+DB query
+
+=cut
+
 extends 'fingerbank::Base::Schema::CombinationMacVendorByDevice';
+
+=head1 AUTHOR
+Inverse inc. <info@inverse.ca>
+=head1 COPYRIGHT
+Copyright (C) 2005-2017 Inverse inc.
+=head1 LICENSE
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+=cut
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/fingerbank/Schema/Local/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Schema/Local/CombinationMacVendorByDevice.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Local::CombinationMacVendorByDevice;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::CombinationMacVendorByDevice';
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/fingerbank/Schema/Upstream/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Schema/Upstream/CombinationMacVendorByDevice.pm
@@ -3,7 +3,36 @@ package fingerbank::Schema::Upstream::CombinationMacVendorByDevice;
 use Moose;
 use namespace::autoclean;
 
+=head1 NAME
+
+fingerbank::Schema::Upstream::CombinationMacVendorByDevice - DB query
+
+=head1 DESCRIPTION
+
+DB query
+
+=cut
+
 extends 'fingerbank::Base::Schema::CombinationMacVendorByDevice';
+
+=head1 AUTHOR
+Inverse inc. <info@inverse.ca>
+=head1 COPYRIGHT
+Copyright (C) 2005-2017 Inverse inc.
+=head1 LICENSE
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+=cut
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/fingerbank/Schema/Upstream/CombinationMacVendorByDevice.pm
+++ b/lib/fingerbank/Schema/Upstream/CombinationMacVendorByDevice.pm
@@ -1,0 +1,10 @@
+package fingerbank::Schema::Upstream::CombinationMacVendorByDevice;
+
+use Moose;
+use namespace::autoclean;
+
+extends 'fingerbank::Base::Schema::CombinationMacVendorByDevice';
+
+__PACKAGE__->meta->make_immutable;
+
+1;


### PR DESCRIPTION
# Description
This is a new DB query to find the matching device_id matching a mac_vendor_id

# Impacts
Device Registration in PF

# Code / PR Dependencies
https://github.com/inverse-inc/packetfence/pull/2337

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added a new query to be able to do a matching of device_id by mac_vendor_id, used in the module device-registration of PacketFence
