### PR TITLE
Build fingerbank-perl-client Debian packages in a CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,6 @@
     # to have latest version of gitlab-builpkg-tools
     - apt-get update && apt-get -y dist-upgrade
     - rm -f README.md
-    # get Upstream db 
-    - curl -X GET https://api.fingerbank.org/api/v2/download/db?key=$API_KEY --output db/fingerbank_Upstream.db
     - ci-build-pkg
 
 .rhel_script: &rpm_script
@@ -48,7 +46,6 @@ download_upstream_db:
   artifacts:
     paths:
       - db/fingerbank_Upstream.db
-
 
 # we use YAML anchors to define same parameters for all builds
 build_debian_stretch:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,7 @@
   script:
     # to have latest version of gitlab-builpkg-tools
     - apt-get update && apt-get -y dist-upgrade
-    # Converting to native package (don't use a tar archive)
-    - sed -i "1{s/-2) /$suffix) /}" debian/changelog
-    - sed -i 's/3.0 (quilt)/3.0 (native)/' debian/source/format
-    - rm -f README.md ; rm -rf t/
+    - rm -f README.md
     # get Upstream db 
     - curl -X GET https://api.fingerbank.org/api/v2/download/db?key=$API_KEY --output db/fingerbank_Upstream.db
     - ci-build-pkg
@@ -63,7 +60,6 @@ build_centos_7:
   image: buildpkg/centos:7
   <<: *job_build
   <<: *rpm_script
-
 
 sign:
   image: buildpkg/debian:stretch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,8 @@
 .debian_script: &deb_script
   script:
     # to have latest version of gitlab-builpkg-tools
-    - apt-get update && apt-get -y dist-upgrade
-    - rm -f README.md
+    # - apt-get update && apt-get -y dist-upgrade
+    - export USER='root'; dh_make --createorig -p fingerbank_4.1.3 -s -y -e info@inverse.ca
     - ci-build-pkg
 
 .rhel_script: &rpm_script

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# YAML anchors to reuse code
+### COMMON PARAMETERS
 .build_job: &job_build
   stage: build
   dependencies:
@@ -20,18 +20,21 @@
     - yum install epel-release -y
     - tar c -zf upstream-db.tar $UPSTREAM_DB_FILE
     - ci-build-pkg
-    
+
+### STAGES
 stages:
  - download
  - build
  - sign
  - publish
 
+### VARIABLES
 variables:
   UPSTREAM_DB_URL: https://api.fingerbank.org/api/v2/download/db
   UPSTREAM_DB_FILE: db/fingerbank_Upstream.db
   UPSTREAM_VERSION_FILE: /tmp/upstream_version.txt
 
+### JOBS
 # for debug purpose
 before_script:
   - unset http_proxy ; unset https_proxy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,15 +12,13 @@
 
 .debian_script: &deb_script
   script:
-    # to have latest version of gitlab-builpkg-tools
-    # - apt-get update && apt-get -y dist-upgrade
-    - export USER='root'; dh_make --createorig -p fingerbank_4.1.3 -s -y -e info@inverse.ca
+    - export DEBFULLNAME='Inverse inc.'; dh_make --createorig -p fingerbank_$(cat $UPSTREAM_VERSION_FILE) -s -y -e info@inverse.ca
     - ci-build-pkg
 
 .rhel_script: &rpm_script
   script:
     - yum install epel-release -y
-    - tar c -zf upstream-db.tar db/fingerbank_Upstream.db
+    - tar c -zf upstream-db.tar $UPSTREAM_DB_FILE
     - ci-build-pkg
     
 stages:
@@ -28,6 +26,11 @@ stages:
  - build
  - sign
  - publish
+
+variables:
+  UPSTREAM_DB_URL: https://api.fingerbank.org/api/v2/download/db
+  UPSTREAM_DB_FILE: db/fingerbank_Upstream.db
+  UPSTREAM_VERSION_FILE: /tmp/upstream_version.txt
 
 # for debug purpose
 before_script:
@@ -37,15 +40,19 @@ before_script:
 download_upstream_db:
   image: buildpkg/debian:stretch
   stage: download
-  # secret variables defined
+  # secret variable defined
   # API_KEY = fingerbank API KEY
   script:
     # get Upstream DB (not part of source)
-    - curl --retry 3 --fail -X GET https://api.fingerbank.org/api/v2/download/db?key=$API_KEY --output db/fingerbank_Upstream.db
+    - curl --retry 3 --fail -X GET $UPSTREAM_DB_URL?key=$API_KEY --output $UPSTREAM_DB_FILE
+    - apt install libreadonly-perl
+    # get Upstream version from source code (workaround for https://gitlab.com/gitlab-org/gitlab-ce/issues/47517)
+    - perl -I'lib/fingerbank' -M'Constant' -e 'print "$fingerbank::Constant::VERSION"' > $UPSTREAM_VERSION_FILE
   # pass artifact to build jobs
   artifacts:
     paths:
-      - db/fingerbank_Upstream.db
+      - $UPSTREAM_DB_FILE
+      - $UPSTREAM_VERSION_FILE
 
 # we use YAML anchors to define same parameters for all builds
 build_debian_stretch:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fingerbank (4.1.3-2) unstable; urgency=low
+
+  * Adapt Debian packaging to CI
+
+ -- Inverse inc. <info@inverse.ca>  Mon, 29 Apr 2019 12:15:08 +0200
+
 fingerbank (4.1.3-1) unstable; urgency=low
 
   * Version 4.1.3

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Inverse inc. <info@inverse.ca>
 Build-Depends: debhelper (>= 7.0.50~), curl
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/inverse-inc/fingerbank.git
-Vcs-browser: https://github.com/inverse-inc/fingerbank/
+Vcs-Browser: https://github.com/inverse-inc/fingerbank/
 Homepage: http://www.fingerbank.org/
 
 Package: fingerbank

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: fingerbank
 Section: net
 Priority: optional
-Maintainer: Durand fabrice <fdurand@inverse.ca>
+Maintainer: Inverse inc. <info@inverse.ca>
 Build-Depends: debhelper (>= 7.0.50~), curl
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/inverse-inc/fingerbank.git

--- a/debian/rules
+++ b/debian/rules
@@ -32,8 +32,7 @@ clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp configure-stamp
-
-
+	rm -rf README.md t/ rpm/
 	dh_clean 
 
 install: build


### PR DESCRIPTION
# Description
Build fingerbank-perl-client in a CI pipeline using GitLab and gitlab-buildpkg-tools

# Impacts
- current and new packaging
- installation of fingerbank-perl-client on Debian systems
- new version on fingerbank's packages

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Build fingerbank-perl-client Debian packages in a CI pipeline
