### PR TITLE
Allow fingerbank to be installed without packetfence on Debian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fingerbank (4.1.3-3) unstable; urgency=medium
+
+  * Allow fingerbank to be installed without packetfence on Debian
+
+ -- Inverse inc. <info@inverse.ca>  Fri, 28 Jun 2019 14:28:17 +0200
+
 fingerbank (4.1.3-2) unstable; urgency=low
 
   * Adapt Debian packaging to CI

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Depends: ${misc:Depends},
  libdbd-sqlite3-perl, liblwp-protocol-https-perl, sqlite3,
  libdata-powerset-perl,
  liblwp-protocol-connect-perl,
+ libjson-perl,
  libsql-translator-perl, libfile-touch-perl, libconfig-inifiles-perl (>= 2.88),
  fingerbank-collector (>= 1.0.1),
 Description: fingerbank

--- a/debian/fingerbank.postinst
+++ b/debian/fingerbank.postinst
@@ -30,7 +30,6 @@ case "$1" in
         make init-db-local
         make fixpermissions
         /usr/local/fingerbank/conf/upgrade/*
-        chown pf.pf /usr/local/fingerbank/conf/fingerbank.conf
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
# Description
- Add a missing dependency
- Use same rights as CentOS 7 on `fingerbank.conf` file
- Update changelog

# Impacts
Installation of `fingerbank` package under Debian

# Issue
fixes #40 
fixes #39 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow fingerbank to be installed without packetfence on Debian
